### PR TITLE
[SHOT-3257] Fill both the thumbnail and the attachment fields on the Note entity

### DIFF
--- a/hooks/tk-multi-publish2/basic/publish_variants.py
+++ b/hooks/tk-multi-publish2/basic/publish_variants.py
@@ -133,7 +133,7 @@ class PublishVariantsPlugin(HookBaseClass):
             publisher.shotgun.upload(entity_type="Note",
                                      entity_id=note.get("id"),
                                      path=variant_path,
-                                     field_name="sg_thumbnail")
+                                     field_name="attachments")
 
     def finalize(self, settings, item):
         """

--- a/hooks/tk-multi-publish2/basic/publish_variants.py
+++ b/hooks/tk-multi-publish2/basic/publish_variants.py
@@ -133,7 +133,8 @@ class PublishVariantsPlugin(HookBaseClass):
             publisher.shotgun.upload(entity_type="Note",
                                      entity_id=note.get("id"),
                                      path=variant_path,
-                                     field_name="attachments")
+                                     field_name="attachments",
+                                     display_name="Variant Image")
 
     def finalize(self, settings, item):
         """

--- a/hooks/tk-multi-publish2/basic/publish_variants.py
+++ b/hooks/tk-multi-publish2/basic/publish_variants.py
@@ -130,6 +130,11 @@ class PublishVariantsPlugin(HookBaseClass):
                                                entity_id=note.get("id"),
                                                path=variant_path)
 
+            publisher.shotgun.upload(entity_type="Note",
+                                     entity_id=note.get("id"),
+                                     path=variant_path,
+                                     field_name="sg_thumbnail")
+
     def finalize(self, settings, item):
         """
         Execute the finalization pass. This pass executes once all the publish


### PR DESCRIPTION
Upload thumbnail in sg_thumbnail when publishing variants