### PR TITLE
[SHOT-3464] Rename "Import into Scene" to "Create Canvas"

### DIFF
--- a/hooks/tk-multi-loader2/basic/scene_actions.py
+++ b/hooks/tk-multi-loader2/basic/scene_actions.py
@@ -111,7 +111,7 @@ class AliasActions(HookBaseClass):
                 {
                     "name": "texture_node",
                     "params": None,
-                    "caption": "Import into Scene",
+                    "caption": "Create Canvas",
                     "description": "This will import the item into the current universe.",
                 }
             )

--- a/hooks/tk-multi-shotgunpanel/basic/scene_actions.py
+++ b/hooks/tk-multi-shotgunpanel/basic/scene_actions.py
@@ -96,7 +96,7 @@ class AliasActions(HookBaseClass):
                 {
                     "name": "texture_node",
                     "params": None,
-                    "caption": "Import into Scene",
+                    "caption": "Create Canvas",
                     "description": "This will import the item into the current universe.",
                 }
             )


### PR DESCRIPTION
* Rename 'texture_node' action label "Import into Scene" to "Create Canvas". This is intended for 2D published file types:  JPEG, PNG, PSD, TIF, BMP.