### PR TITLE
Added support for Prepare New Operation hook

### DIFF
--- a/hooks/tk-multi-workfiles2/basic/scene_operation.py
+++ b/hooks/tk-multi-workfiles2/basic/scene_operation.py
@@ -73,7 +73,10 @@ class SceneOperation(HookClass):
 
             if operation == "current_path":
                 return alias_api.get_current_path()
-
+            
+            elif operation == "prepare_new":
+                pass
+                
             elif operation == "open":
                 # if the current file is an empty file, we can erase it and open the new file instead
                 if alias_api.is_empty_file():


### PR DESCRIPTION
For some deep dive videos , I'd like this operation hook to already exist to simplify it for future modifiers. It appears a "prepare_new" hook isn't needed so I didn't add any logic.