### PR TITLE
Defer Alias callbacks until all API operations have completed

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -345,7 +345,69 @@ class AliasEngine(sgtk.platform.Engine):
         self._contexts_by_stage_name[current_stage.name] = context
 
     #####################################################################################
-    # Alias Callbacks
+    # Alias Event Watcher & Callbacks
+
+    def execute_api_ops_and_defer_event_callbacks(self, alias_api_ops, event_types):
+        """
+        Call an Alias API function while blocking any Alias event callbacks until the
+        API function is done executing. Once finished, the registered Python callbacks
+        will be triggered for the event types provided. Any event types not provided
+        will not be triggered at all by the API function executed.
+
+        NOTE since the callbacks are deferred to after the event operation has completed,
+        we do not have access to the Alias callback return result that we normally get.
+
+        TODO implement this deferred event handling in the Alias Python API side, for now
+        we will just pass None for the message result to the Python callback function.
+        Implementing the deferred event handling will also improve the way we currently
+        ignore event callbacks by unregistering and re-registering events.
+
+        :param alias_api_ops: The name of the main Alias API function to execute.
+        :type alias_api_ops: list<AliasApiOp>, where AliasApiOp is of format:
+            tuple<alias_api_func_name, func_args, func_keyword_args>
+                alias_api_func: str
+                args: list
+                kwargs: dict
+        :param event_types: The Alias event types to defer callbacks until the main
+                            operation is complete. Any event types that are not listed
+                            will not be triggered at all for for this operation.
+        :type event_types: list<AlMessageType>
+        """
+
+        # Check that all api functions exist, if not abort
+        for api_func, _, _ in alias_api_ops:
+            if not hasattr(alias_api, api_func):
+                self.logger.error(
+                    "Failed execute_api_ops_and_defer_event_callbcaks: Alias Python API function not found '{}'".format(
+                        api_func
+                    )
+                )
+                return
+
+        if not isinstance(event_types, list):
+            event_types = [event_types]
+
+        if not self.event_watcher.is_watching:
+            # If the event watcher is already paused, just execute the the operations normally.
+            for api_func, args, kwargs in alias_api_ops:
+                getattr(alias_api, api_func)(*args, **kwargs)
+
+        else:
+            # Pause the event watcher
+            self.event_watcher.stop_watching()
+
+            # Execute all alias api operations in order
+            for api_func, args, kwargs in alias_api_ops:
+                getattr(alias_api, api_func)(*args, **kwargs)
+
+            # Enable the event watcher now that the operations have completed
+            self.event_watcher.start_watching()
+
+            # Now manually trigger the registered callbacks for the event types
+            for event_type in event_types:
+                callback_fns = self.event_watcher.get_callbacks(event_type)
+                for callback_fn in callback_fns:
+                    callback_fn(msg=None)
 
     def on_plugin_init(self):
         """

--- a/hooks/tk-multi-snapshot/basic/scene_operation.py
+++ b/hooks/tk-multi-snapshot/basic/scene_operation.py
@@ -65,11 +65,7 @@ class SceneOperation(HookClass):
                     self.parent.engine.execute_api_ops_and_defer_event_callbacks(
                         [
                             ("reset", [], {}),
-                            (
-                                "open_file",
-                                [file_path],
-                                {"new_stage": False, "delete_current": False},
-                            ),
+                            ("open_file", [file_path], {"new_stage": False},),
                         ],
                         alias_api.AlMessageType.StageActive,
                     )

--- a/hooks/tk-multi-snapshot/basic/scene_operation.py
+++ b/hooks/tk-multi-snapshot/basic/scene_operation.py
@@ -55,6 +55,7 @@ class SceneOperation(HookClass):
                         [
                             (
                                 "open_file",
+                                None,  # indicate this ia function of the api module
                                 [file_path],
                                 {"new_stage": False, "delete_current": True},
                             ),
@@ -64,8 +65,8 @@ class SceneOperation(HookClass):
                 else:
                     self.parent.engine.execute_api_ops_and_defer_event_callbacks(
                         [
-                            ("reset", [], {}),
-                            ("open_file", [file_path], {"new_stage": False},),
+                            ("reset", None, [], {}),
+                            ("open_file", None, [file_path], {"new_stage": False},),
                         ],
                         alias_api.AlMessageType.StageActive,
                     )

--- a/hooks/tk-multi-snapshot/basic/scene_operation.py
+++ b/hooks/tk-multi-snapshot/basic/scene_operation.py
@@ -51,10 +51,28 @@ class SceneOperation(HookClass):
                 if open_in_current_stage == QtGui.QMessageBox.Cancel:
                     return
                 elif open_in_current_stage == QtGui.QMessageBox.No:
-                    alias_api.open_file(file_path, new_stage=False, delete_current=True)
+                    self.parent.engine.execute_api_ops_and_defer_event_callbacks(
+                        [
+                            (
+                                "open_file",
+                                [file_path],
+                                {"new_stage": False, "delete_current": True},
+                            ),
+                        ],
+                        alias_api.AlMessageType.StageActive,
+                    )
                 else:
-                    alias_api.reset()
-                    alias_api.open_file(file_path, new_stage=False)
+                    self.parent.engine.execute_api_ops_and_defer_event_callbacks(
+                        [
+                            ("reset", [], {}),
+                            (
+                                "open_file",
+                                [file_path],
+                                {"new_stage": False, "delete_current": False},
+                            ),
+                        ],
+                        alias_api.AlMessageType.StageActive,
+                    )
 
             elif operation == "save":
                 alias_api.save_file()

--- a/hooks/tk-multi-workfiles2/basic/scene_operation.py
+++ b/hooks/tk-multi-workfiles2/basic/scene_operation.py
@@ -78,7 +78,7 @@ class SceneOperation(HookClass):
                 # if the current file is an empty file, we can erase it and open the new file instead
                 if alias_api.is_empty_file():
                     self.parent.engine.execute_api_ops_and_defer_event_callbacks(
-                        [("open_file", [file_path], {"new_stage": False})],
+                        [("open_file", None, [file_path], {"new_stage": False})],
                         alias_api.AlMessageType.StageActive,
                     )
                 # otherwise, ask the use what he'd like to do
@@ -90,15 +90,15 @@ class SceneOperation(HookClass):
                         return
                     elif open_in_current_stage == QtGui.QMessageBox.No:
                         self.parent.engine.execute_api_ops_and_defer_event_callbacks(
-                            [("open_file", [file_path], {"new_stage": True})],
+                            [("open_file", None, [file_path], {"new_stage": True})],
                             alias_api.AlMessageType.StageActive,
                         )
                     else:
                         # alias_api.reset()
                         self.parent.engine.execute_api_ops_and_defer_event_callbacks(
                             [
-                                ("reset", [], {}),
-                                ("open_file", [file_path], {"new_stage": False}),
+                                ("reset", None, [], {}),
+                                ("open_file", None, [file_path], {"new_stage": False}),
                             ],
                             alias_api.AlMessageType.StageActive,
                         )
@@ -116,7 +116,7 @@ class SceneOperation(HookClass):
                     return True
                 if alias_api.is_empty_file() and len(alias_api.get_stages()) == 1:
                     self.parent.engine.execute_api_ops_and_defer_event_callbacks(
-                        [("reset", [], {})], alias_api.AlMessageType.StageActive,
+                        [("reset", None, [], {})], alias_api.AlMessageType.StageActive,
                     )
                     return True
                 else:
@@ -128,12 +128,13 @@ class SceneOperation(HookClass):
                     elif open_in_current_stage == QtGui.QMessageBox.No:
                         stage_name = uuid.uuid4().hex
                         self.parent.engine.execute_api_ops_and_defer_event_callbacks(
-                            [("create_stage", [stage_name], {})],
+                            [("create_stage", None, [stage_name], {})],
                             alias_api.AlMessageType.StageActive,
                         )
                     else:
                         self.parent.engine.execute_api_ops_and_defer_event_callbacks(
-                            [("reset", [], {})], alias_api.AlMessageType.StageActive,
+                            [("reset", None, [], {})],
+                            alias_api.AlMessageType.StageActive,
                         )
                     return True
 

--- a/hooks/tk-multi-workfiles2/basic/scene_operation.py
+++ b/hooks/tk-multi-workfiles2/basic/scene_operation.py
@@ -77,7 +77,10 @@ class SceneOperation(HookClass):
             elif operation == "open":
                 # if the current file is an empty file, we can erase it and open the new file instead
                 if alias_api.is_empty_file():
-                    alias_api.open_file(file_path, new_stage=False)
+                    self.parent.engine.execute_api_ops_and_defer_event_callbacks(
+                        [("open_file", [file_path], {"new_stage": False})],
+                        alias_api.AlMessageType.StageActive,
+                    )
                 # otherwise, ask the use what he'd like to do
                 else:
                     open_in_current_stage = (
@@ -86,10 +89,19 @@ class SceneOperation(HookClass):
                     if open_in_current_stage == QtGui.QMessageBox.Cancel:
                         return
                     elif open_in_current_stage == QtGui.QMessageBox.No:
-                        alias_api.open_file(file_path, new_stage=True)
+                        self.parent.engine.execute_api_ops_and_defer_event_callbacks(
+                            [("open_file", [file_path], {"new_stage": True})],
+                            alias_api.AlMessageType.StageActive,
+                        )
                     else:
-                        alias_api.reset()
-                        alias_api.open_file(file_path, new_stage=False)
+                        # alias_api.reset()
+                        self.parent.engine.execute_api_ops_and_defer_event_callbacks(
+                            [
+                                ("reset", [], {}),
+                                ("open_file", [file_path], {"new_stage": False}),
+                            ],
+                            alias_api.AlMessageType.StageActive,
+                        )
 
             elif operation == "save":
                 alias_api.save_file()
@@ -103,7 +115,9 @@ class SceneOperation(HookClass):
                 if parent_action == "open_file":
                     return True
                 if alias_api.is_empty_file() and len(alias_api.get_stages()) == 1:
-                    alias_api.reset()
+                    self.parent.engine.execute_api_ops_and_defer_event_callbacks(
+                        [("reset", [], {})], alias_api.AlMessageType.StageActive,
+                    )
                     return True
                 else:
                     open_in_current_stage = self.parent.engine.open_delete_stages_dialog(
@@ -113,9 +127,14 @@ class SceneOperation(HookClass):
                         return False
                     elif open_in_current_stage == QtGui.QMessageBox.No:
                         stage_name = uuid.uuid4().hex
-                        alias_api.create_stage(stage_name)
+                        self.parent.engine.execute_api_ops_and_defer_event_callbacks(
+                            [("create_stage", [stage_name], {})],
+                            alias_api.AlMessageType.StageActive,
+                        )
                     else:
-                        alias_api.reset()
+                        self.parent.engine.execute_api_ops_and_defer_event_callbacks(
+                            [("reset", [], {})], alias_api.AlMessageType.StageActive,
+                        )
                     return True
 
         finally:

--- a/python/tk_alias/alias_event_watcher.py
+++ b/python/tk_alias/alias_event_watcher.py
@@ -40,6 +40,19 @@ class AliasEventWatcher(object):
         """
         return self.__is_watching
 
+    def get_callbacks(self, scene_event):
+        """
+        Get the list of Python callback functions for the Alias event type.
+
+        :param scene_event: The Alias event type
+        :type scene_event: alias_api.AlMessageType
+
+        :return: The list of Python callback functions.
+        :rtype: list<callable>
+        """
+
+        return self.__scene_events.get(scene_event, {}).keys()
+
     def register_alias_callback(self, cb_fn, scene_events):
         """
         Add the given callback to the list of registered callbacks


### PR DESCRIPTION
Added a method to the engine to call a list of Alias API functions while blocking any event callbacks until all operations are complete. This resolves issues that occur when a file is in the middle of opening and Alias callbacks trigger other python code to execute.