### PR TITLE
SHOT-2950: Load image onto Construction plane

### DIFF
--- a/hooks/tk-multi-loader2/basic/scene_actions.py
+++ b/hooks/tk-multi-loader2/basic/scene_actions.py
@@ -267,7 +267,7 @@ class AliasActions(HookBaseClass):
         """
         if not os.path.exists(path):
             raise Exception("File not found on disk - '%s'" % path)
-        alias_api.create_texture_node(path)
+        alias_api.create_texture_node(path, True)
 
     def _import_subdivision(self, path):
         """

--- a/hooks/tk-multi-shotgunpanel/basic/scene_actions.py
+++ b/hooks/tk-multi-shotgunpanel/basic/scene_actions.py
@@ -268,7 +268,7 @@ class AliasActions(HookBaseClass):
         """
         if not os.path.exists(path):
             raise Exception("File not found on disk - '%s'" % path)
-        alias_api.create_texture_node(path)
+        alias_api.create_texture_node(path, True)
 
     def _import_subdivision(self, path):
         """


### PR DESCRIPTION
Pass param `True` to Alias Python API function to load canvas onto construction plane, if one is picked at creation time, else it will load it oriented toward the current camera.