### PR TITLE
SHOT-3963: Improve Alis Event initialization

### DIFF
--- a/python/tk_alias/alias_event_watcher.py
+++ b/python/tk_alias/alias_event_watcher.py
@@ -132,9 +132,14 @@ class AliasEventWatcher(object):
 
         self.__is_watching = True
 
-    def stop_watching(self):
+    def stop_watching(self, force=False):
         """
         Stops watching the scene events.
+
+        :param force: Set to True to perform stop watching operations regardless of current
+            watching state, else False to only perform stop watching operations if currently
+            watching events.
+        :type force: bool
         """
 
         if not self.is_watching:
@@ -148,3 +153,11 @@ class AliasEventWatcher(object):
                 self.__scene_events[ev][cb_fn] = None
 
         self.__is_watching = False
+
+    def shutdown(self):
+        """
+        Shut down the event watcher.
+        """
+
+        self.stop_watching(force=True)
+        self.__scene_events = None


### PR DESCRIPTION
* The Alias SG Plugin will be updated to not add message handlers, if necessary, leaving the onus on the Engine to add any handlers as needed
* Use lambda to access the Engine object during the Alias C++ calling the Python callback function for an event
* Rename function on_stage_selected to on_stage_created to be more accurate as to when the function is called
* Add shutdown method to AliasEventWatcher
* Add force parameter to AliasEventWatcher.stop_watching to force stop watching

@barbara-darkshot flagging that I renamed the function to more accurately describe when it is called. Just want to double -check with you that there are no script or code outside of tk-alias that uses this function?
`on_stage_selected` to `on_stage_created`