### PR TITLE
SHOT-4044: Fix local variable 'note_links' referenced before assignment error.

### DIFF
--- a/hooks/tk-multi-publish2/basic/publish_annotations.py
+++ b/hooks/tk-multi-publish2/basic/publish_annotations.py
@@ -122,25 +122,25 @@ class PublishAnnotationsPlugin(HookBaseClass):
             if version_data is not None:
                 note_links.append(version_data)
 
-        annotations = alias_api.get_annotation_locator_strings()
+            annotations = alias_api.get_annotation_locator_strings()
 
-        batch_data = []
-        for annotation in annotations:
-            note_data = {
-                "project": item.context.project,
-                "user": item.context.user,
-                "subject": "Alias Annotation",
-                "content": annotation,
-                "note_links": note_links,
-            }
-            if item.context.task:
-                note_data["tasks"] = [item.context.task]
-            batch_data.append(
-                {"request_type": "create", "entity_type": "Note", "data": note_data}
-            )
+            batch_data = []
+            for annotation in annotations:
+                note_data = {
+                    "project": item.context.project,
+                    "user": item.context.user,
+                    "subject": "Alias Annotation",
+                    "content": annotation,
+                    "note_links": note_links,
+                }
+                if item.context.task:
+                    note_data["tasks"] = [item.context.task]
+                batch_data.append(
+                    {"request_type": "create", "entity_type": "Note", "data": note_data}
+                )
 
-        if batch_data:
-            self.parent.shotgun.batch(batch_data)
+            if batch_data:
+                self.parent.shotgun.batch(batch_data)
 
     def finalize(self, settings, item):
         """


### PR DESCRIPTION
1. If we are not background processing or are in the background process, then we get the note links to include in creating the annotation notes.

2. If we are background processing and in the background process, then we do not get note links to attach, BUT we continue to create annotation notes (without note links).

@barbara-darkshot In **2.** we continue to create the annotation notes even though we do not have access to the note links. Is this the intended behaviour?