### PR TITLE
SHOT-4162: Fix data validation performance

### DIFF
--- a/python/tk_alias/data_validator.py
+++ b/python/tk_alias/data_validator.py
@@ -569,7 +569,7 @@ class AliasDataValidator(object):
                 "description": """Check: Curves<br/>
                                 Fix: Delete""",
                 "check_func": self.check_node_curves,
-                "fix_func": self.fix_node_curves,
+                "fix_func": self.fix_all_node_curves,
                 "fix_name": "Delete All",
                 "fix_tooltip": "Delete all curves found.",
                 "error_msg": "Found curve(s).",
@@ -1635,10 +1635,29 @@ class AliasDataValidator(object):
         )
 
     @sgtk.LogManager.log_timing
+    def fix_all_node_curves(self, errors=None):
+        """
+        Delete all nodes that represent a curve.
+
+        :param errors: This param is ignored, though it is required to be defiend for this
+            function to be a data validation fix callback.
+        :type errors: N/A
+        :param skip_node_types: The specified node types will not be fixed.
+        :type skip_node_types: list<alias_api.AlObjectType>
+
+        :raises alias_api.AliasPythonException: if a failed to set a node's transform to zero
+        """
+
+        # Call the main fix function but do not pass an errors list to indicate that all nodes
+        # should be processed. This will improve performance.
+        self.fix_node_curves(errors=None)
+
+    @sgtk.LogManager.log_timing
     def fix_node_curves(self, errors=None):
         """
-        Process all nodes in the current stage, or the list of nodes if provided, and delete all nodes that
-        represent a curve.
+        Delete the specified nodes that represent a curve.
+
+        If a list of nodes are passed in, they are assumed to represent a curve and will be deleted.
 
         :param errors: The list of nodes to process, if None, all nodes in the current stage will be
             processed. Default=None
@@ -1651,6 +1670,7 @@ class AliasDataValidator(object):
                     errors[i] = error_item["name"]
 
         if errors:
+            # NOTE this assumes all nodes passed in represent a curve.
             alias_py.dag_node.delete_nodes(errors)
 
         else:

--- a/python/tk_alias/data_validator.py
+++ b/python/tk_alias/data_validator.py
@@ -1264,7 +1264,6 @@ class AliasDataValidator(object):
             for i, error_item in enumerate(errors):
                 if isinstance(error_item, dict):
                     errors[i] = error_item["name"]
-        
 
         # NOTE for best performance when applying zero transform to many nodes at a time,
         # we should call the specific Alias API function to apply the zero transform
@@ -1764,7 +1763,6 @@ class AliasDataValidator(object):
         # )
         # for curve in unused_curves:
         #     curve.delete_object()
-
 
     @sgtk.LogManager.log_timing
     def check_curve_on_surface_construction_history(self, fail_fast=False):

--- a/python/tk_alias/data_validator.py
+++ b/python/tk_alias/data_validator.py
@@ -1179,7 +1179,7 @@ class AliasDataValidator(object):
         Check for nodes with non-zero transforms in the current stage.
 
         Only top-level dag nodes will be returned.
-        
+
         :param fail_fast: Not applicable, but keep this param to follow guidelines for check functions.
         :type fail_fast: bool
         :param skip_node_types: The specified node types will not be checked.
@@ -1191,7 +1191,7 @@ class AliasDataValidator(object):
         """
 
         skip_node_types = skip_node_types or []
-       
+
         all_nodes = alias_py.dag_node.get_nodes_with_non_zero_transform(
             skip_node_types=set(skip_node_types),
         )
@@ -1203,7 +1203,6 @@ class AliasDataValidator(object):
                 nodes.append(node)
 
         return nodes
-
 
     @sgtk.LogManager.log_timing
     def fix_all_node_has_zero_transform(self, errors=None, skip_node_types=None):
@@ -1277,7 +1276,6 @@ class AliasDataValidator(object):
                 )
         else:
             __apply_zero_transform_top_level()
-            
 
     @sgtk.LogManager.log_timing
     def check_node_is_not_in_layer(

--- a/python/tk_alias/data_validator.py
+++ b/python/tk_alias/data_validator.py
@@ -176,7 +176,6 @@ class AliasDataValidator(object):
                 "fix_tooltip": "Delete all null nodes.",
                 "warn_msg": 'This validation does not return a status. To ensure all null nodes are deleted, select "Delete All" or "Fix All."',
                 "dependency_ids": [
-                    "node_has_construction_history",
                     "curves",
                 ],
             },

--- a/python/tk_alias/data_validator.py
+++ b/python/tk_alias/data_validator.py
@@ -178,6 +178,7 @@ class AliasDataValidator(object):
                 "warn_msg": 'This validation does not return a status. To ensure all null nodes are deleted, select "Delete All" or "Fix All."',
                 "dependency_ids": [
                     "node_has_construction_history",
+                    "curves",
                 ],
             },
             "node_has_construction_history": {
@@ -588,7 +589,7 @@ class AliasDataValidator(object):
                         "callback": self.pick_nodes,
                     },
                 ],
-                "dependency_ids": ["node_has_construction_history", "node_is_null"],
+                "dependency_ids": ["node_has_construction_history"],
             },
             "set_empty": {
                 "name": "Delete Empty Selection Sets",

--- a/python/tk_alias/data_validator.py
+++ b/python/tk_alias/data_validator.py
@@ -309,7 +309,11 @@ class AliasDataValidator(object):
                         *self._light_node_types,
                     ]
                 },
-                "dependency_ids": ["node_has_construction_history", "node_is_null"],
+                "dependency_ids": [
+                    "node_has_construction_history",
+                    "node_is_null",
+                    "node_instances",
+                ],
             },
             "node_is_not_in_layer": {
                 "name": "Nodes Must Not Be In DefaultLayer",

--- a/python/tk_alias/data_validator.py
+++ b/python/tk_alias/data_validator.py
@@ -555,7 +555,7 @@ class AliasDataValidator(object):
                 "item_actions": [
                     {
                         "name": "Delete",
-                        "callback": self.fix_curve_on_surface_unused,
+                        "callback": self.fix_curve_on_surface_construction_history,
                     },
                     {
                         "name": "Select COS",

--- a/python/tk_alias/data_validator.py
+++ b/python/tk_alias/data_validator.py
@@ -283,8 +283,7 @@ class AliasDataValidator(object):
                 "check_func": self.check_node_has_zero_transform,
                 "fix_func": self.fix_node_has_zero_transform,
                 "fix_name": "Reset All",
-                "fix_tooltip": "Reset all transforms to zero. Camera, light, and texture nodes are not affected."
-                "",
+                "fix_tooltip": "Reset all transforms to zero. Camera, light, and texture nodes are not affected.",
                 "error_msg": "Found node(s) with non-zero transform.",
                 "actions": [
                     {

--- a/python/tk_alias/data_validator.py
+++ b/python/tk_alias/data_validator.py
@@ -144,7 +144,6 @@ class AliasDataValidator(object):
                 ],
                 "get_kwargs": lambda: {"skip_shaders": [self.DEFAULT_SHADER_NAME]},
                 "dependency_ids": [
-                    "node_is_null",
                     "node_instances",
                 ],
             },
@@ -240,7 +239,7 @@ class AliasDataValidator(object):
                         "callback": self.pick_nodes,
                     },
                 ],
-                "dependency_ids": ["node_has_construction_history", "node_is_null"],
+                "dependency_ids": ["node_is_null"],
             },
             "node_pivots_at_origin": {
                 "name": "Reset Pivots to Global Origin",
@@ -268,7 +267,7 @@ class AliasDataValidator(object):
                         "callback": self.pick_nodes,
                     },
                 ],
-                "dependency_ids": ["node_has_construction_history", "node_is_null"],
+                "dependency_ids": ["node_is_null"],
                 "get_kwargs": lambda: {
                     "skip_node_types": [
                         alias_api.AlObjectType.TextureNodeType,
@@ -305,13 +304,12 @@ class AliasDataValidator(object):
                 "get_kwargs": lambda: {
                     "skip_node_types": [
                         alias_api.AlObjectType.TextureNodeType,
+                        alias_api.AlObjectType.GroupNodeType,
                         *self._camera_node_types,
                         *self._light_node_types,
                     ]
                 },
                 "dependency_ids": [
-                    "node_has_construction_history",
-                    "node_is_null",
                     "node_instances",
                 ],
             },
@@ -491,7 +489,7 @@ class AliasDataValidator(object):
                         "callback": self.pick_nodes,
                     },
                 ],
-                "dependency_ids": ["node_has_construction_history", "node_is_null"],
+                "dependency_ids": ["node_is_null"],
             },
             "cos_unused": {
                 "name": "Delete Unused Curves-on-Surfaces (COS)",
@@ -528,7 +526,6 @@ class AliasDataValidator(object):
                 ],
                 "dependency_ids": [
                     "cos_construction_history",
-                    "node_has_construction_history",
                     "node_is_null",
                 ],
             },


### PR DESCRIPTION
Data validation performance regression found for dag node checks. The issue is caused by processing nodes one by one, instead of using the more performant Alias Python API traverse methods (which was caused by the data validation app passing the full list of nodes to the fix functions, instead of None which used to indicate to process all nodes).