### PR TITLE
Fix listening for Alias events

### DIFF
--- a/python/tk_alias/alias_event_watcher.py
+++ b/python/tk_alias/alias_event_watcher.py
@@ -87,10 +87,10 @@ class AliasEventWatcher(object):
             if self.ignore_events:
                 # Clear the queued events, but do not trigger their callacks.
                 alias_api.clear_queued_events()
-            else:
-                # Trigger any Python callbacks for the queued events. The queue will become
-                # empty after this.
-                alias_api.queue_events(False)
+
+            # Trigger any Python callbacks for the queued events. The queue will become
+            # empty after this.
+            alias_api.queue_events(False)
 
     def __init__(self):
         """


### PR DESCRIPTION
* ContextManager on exit should start listening for Alias events again, even when ignore_events is True
* This bug caused Alias events to be ignored forever until user turns it back on themselves