### PR TITLE
Specify all dependencies for data validation rule

### DIFF
--- a/python/tk_alias/data_validator.py
+++ b/python/tk_alias/data_validator.py
@@ -145,6 +145,9 @@ class AliasDataValidator(object):
                 "get_kwargs": lambda: {"skip_shaders": [self.DEFAULT_SHADER_NAME]},
                 "dependency_ids": [
                     "node_instances",
+                    "node_is_null",
+                    "curves",
+                    "node_has_construction_history",
                 ],
             },
             "shader_is_vred_compatible": {
@@ -177,6 +180,7 @@ class AliasDataValidator(object):
                 "warn_msg": 'This validation does not return a status. To ensure all null nodes are deleted, select "Delete All" or "Fix All."',
                 "dependency_ids": [
                     "curves",
+                    "node_has_construction_history",
                 ],
             },
             "node_has_construction_history": {
@@ -238,7 +242,11 @@ class AliasDataValidator(object):
                         "callback": self.pick_nodes,
                     },
                 ],
-                "dependency_ids": ["node_is_null"],
+                "dependency_ids": [
+                    "node_is_null",
+                    "curves",
+                    "node_has_construction_history",
+                ],
             },
             "node_pivots_at_origin": {
                 "name": "Reset Pivots to Global Origin",
@@ -266,7 +274,11 @@ class AliasDataValidator(object):
                         "callback": self.pick_nodes,
                     },
                 ],
-                "dependency_ids": ["node_is_null"],
+                "dependency_ids": [
+                    "node_is_null",
+                    "curves",
+                    "node_has_construction_history",
+                ],
                 "get_kwargs": lambda: {
                     "skip_node_types": [
                         alias_api.AlObjectType.TextureNodeType,
@@ -310,6 +322,9 @@ class AliasDataValidator(object):
                 },
                 "dependency_ids": [
                     "node_instances",
+                    "node_is_null",
+                    "curves",
+                    "node_has_construction_history",
                 ],
             },
             "node_is_not_in_layer": {
@@ -339,7 +354,11 @@ class AliasDataValidator(object):
                         *self._light_node_types,
                     ],
                 },
-                "dependency_ids": ["node_is_null"],
+                "dependency_ids": [
+                    "node_is_null",
+                    "curves",
+                    "node_has_construction_history",
+                ],
             },
             "node_is_in_layer": {
                 "name": "Nodes Must Be In DefaultLayer",
@@ -374,7 +393,11 @@ class AliasDataValidator(object):
                         *self._light_node_types,
                     ],
                 },
-                "dependency_ids": ["node_is_null"],
+                "dependency_ids": [
+                    "node_is_null",
+                    "curves",
+                    "node_has_construction_history",
+                ],
             },
             "node_name_matches_layer": {
                 "name": "Match Layer And Assigned Nodes' Names",
@@ -488,7 +511,11 @@ class AliasDataValidator(object):
                         "callback": self.pick_nodes,
                     },
                 ],
-                "dependency_ids": ["node_is_null"],
+                "dependency_ids": [
+                    "node_is_null",
+                    "curves",
+                    "node_has_construction_history",
+                ],
             },
             "cos_unused": {
                 "name": "Delete Unused Curves-on-Surfaces (COS)",
@@ -526,6 +553,8 @@ class AliasDataValidator(object):
                 "dependency_ids": [
                     "cos_construction_history",
                     "node_is_null",
+                    "curves",
+                    "node_has_construction_history",
                 ],
             },
             "cos_construction_history": {
@@ -608,6 +637,8 @@ class AliasDataValidator(object):
                 ],
                 "dependency_ids": [
                     "node_is_null",
+                    "curves",
+                    "node_has_construction_history",
                 ],
             },
             "group_has_single_level_hierarchy": {
@@ -637,6 +668,8 @@ class AliasDataValidator(object):
                 ],
                 "dependency_ids": [
                     "node_is_null",
+                    "curves",
+                    "node_has_construction_history",
                     "layer_has_single_object",
                 ],
             },
@@ -666,7 +699,11 @@ class AliasDataValidator(object):
                     },
                 ],
                 "get_kwargs": lambda: {"skip_layers": [self.DEFAULT_LAYER_NAME]},
-                "dependency_ids": ["node_is_null"],
+                "dependency_ids": [
+                    "node_is_null",
+                    "curves",
+                    "node_has_construction_history",
+                ],
             },
             "layer_has_single_shader": {
                 "name": "Layer Has Single Shader",
@@ -691,6 +728,8 @@ class AliasDataValidator(object):
                 ],
                 "dependency_ids": [
                     "node_is_null",
+                    "curves",
+                    "node_has_construction_history",
                     "node_is_in_layer",
                     "node_is_not_in_layer",
                 ],
@@ -750,10 +789,13 @@ class AliasDataValidator(object):
                 "get_kwargs": lambda: {"skip_layers": [self.DEFAULT_LAYER_NAME]},
                 "dependency_ids": [
                     "layer_is_empty",
+                    "node_has_zero_transform",
+                    "node_instances",
                     "node_is_null",
+                    "curves",
+                    "node_has_construction_history",
                     "node_is_in_layer",
                     "node_is_not_in_layer",
-                    "node_has_zero_transform",
                 ],
             },
             "locators": {


### PR DESCRIPTION
* Must specify all dependencies in each rule because if a dependency is excluded (e.g. by config settings) then the rule will not get the dependencies of the dependency that is excluded.