### PR TITLE
Fix saving the context for Alias stage.

### DIFF
--- a/hooks/tk-multi-workfiles2/basic/scene_operation.py
+++ b/hooks/tk-multi-workfiles2/basic/scene_operation.py
@@ -68,9 +68,8 @@ class SceneOperation(HookClass):
                                 all others     - None
         """
 
-
         # At the end of the scene operation, indicate if the context needs to be saved for the
-        # current Alias stage. 
+        # current Alias stage.
         save_context = operation in ["save_as", "prepare_new", "open", "reset"]
 
         # Use the event watcher context manager to queue any callbacks triggered by Alias


### PR DESCRIPTION
* Save the context for the stage on reset when parent action is new file
* This fixes updating the context correctly when opening a new file from workfiles
* Return False when the file was not opened, this is to ensure the context does not change to the file that was requested to be opened, but was not opened