### PR TITLE
SHOT-4306/SHOT-4321: LMV translation updates and improve thumbnails on publish

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -191,6 +191,11 @@ class AliasEngine(sgtk.platform.Engine):
         """Get the AliasDataValidator object to help validate the Alias data."""
         return self.__data_validator
 
+    @property
+    def executable_path(self):
+        """Get the path to the currently running Alias executable."""
+        return self.alias_execpath
+
     # -------------------------------------------------------------------------------------------------------
     # Override base Engine class methods
     # -------------------------------------------------------------------------------------------------------

--- a/hooks/tk-multi-publish2/basic/collector.py
+++ b/hooks/tk-multi-publish2/basic/collector.py
@@ -139,7 +139,9 @@ class AliasSessionCollector(HookBaseClass):
             ).name
             status = self.alias_py.store_current_window(thumbnail_path)
             if not self.alias_py.py_utils.is_success(status):
-                self.logger.warning(f"Alias API store_current_window returned non-success status code '{status}'")
+                self.logger.warning(
+                    f"Alias API store_current_window returned non-success status code '{status}'"
+                )
             pixmap = QtGui.QPixmap(thumbnail_path)
         except Exception as e:
             self.logger.error(f"Failed to set default thumbnail: {e}")

--- a/hooks/tk-multi-publish2/basic/upload_version.py
+++ b/hooks/tk-multi-publish2/basic/upload_version.py
@@ -260,6 +260,8 @@ class UploadVersionPlugin(HookBaseClass):
 
             uploaded_movie_path = media_package_path or thumbnail_path
             if uploaded_movie_path:
+                # Uplod to the `sg_uploaded_movie` field on the Version so that the Version
+                # thumbnail shows the "play" button on hover from ShotGrid Web
                 self.parent.shotgun.upload(
                     entity_type=version_type,
                     entity_id=version_id,

--- a/hooks/tk-multi-publish2/basic/upload_version.py
+++ b/hooks/tk-multi-publish2/basic/upload_version.py
@@ -227,10 +227,18 @@ class UploadVersionPlugin(HookBaseClass):
             super(UploadVersionPlugin, self).publish(settings, item)
 
             # get or create the media content for the item and upload it to ShotGrid
-            media_package_path, thumbnail_path, temp_dir = self._get_media_content(settings, item)
-            if media_package_path is None and thumbnail_path is None and temp_dir is None:
+            media_package_path, thumbnail_path, temp_dir = self._get_media_content(
+                settings, item
+            )
+            if (
+                media_package_path is None
+                and thumbnail_path is None
+                and temp_dir is None
+            ):
                 media_type = settings.get("Version Type").value
-                self.logger.warning(f"No media content generated for type: {media_type}")
+                self.logger.warning(
+                    f"No media content generated for type: {media_type}"
+                )
 
             version_type = item.properties["sg_version_data"]["type"]
             version_id = item.properties["sg_version_data"]["id"]
@@ -252,7 +260,9 @@ class UploadVersionPlugin(HookBaseClass):
                     path=uploaded_movie_path,
                     field_name="sg_uploaded_movie",
                 )
-                self.logger.info(f"Uploaded Version media from path {uploaded_movie_path}")
+                self.logger.info(
+                    f"Uploaded Version media from path {uploaded_movie_path}"
+                )
 
             if thumbnail_path:
                 # Always upload the generated thumbnail to the Version (this will override any
@@ -262,7 +272,9 @@ class UploadVersionPlugin(HookBaseClass):
                     entity_id=version_id,
                     path=thumbnail_path,
                 )
-                self.logger.info(f"Uploaded Version thumbnail from path {thumbnail_path}")
+                self.logger.info(
+                    f"Uploaded Version thumbnail from path {thumbnail_path}"
+                )
 
                 if not item.get_thumbnail_as_path():
                     # Upload the thumbnail to the associated Published File, if one has not
@@ -567,7 +579,7 @@ class UploadVersionPlugin(HookBaseClass):
         :rtype: Tuple[str,str,str]
         """
 
-        media_package_path = None 
+        media_package_path = None
         thumbnail_path = None
         temp_dir = None
 
@@ -592,7 +604,7 @@ class UploadVersionPlugin(HookBaseClass):
                 temp_dir, thumbnail_path = self._get_thumbnail_from_lmv(
                     item, use_framework_translator
                 )
-        
+
         return media_package_path, thumbnail_path, temp_dir
 
     def _translate_file_to_lmv(self, item, use_framework_translator):

--- a/hooks/tk-multi-publish2/basic/upload_version.py
+++ b/hooks/tk-multi-publish2/basic/upload_version.py
@@ -270,16 +270,6 @@ class UploadVersionPlugin(HookBaseClass):
                     f"Uploaded Version media from path {uploaded_movie_path}"
                 )
 
-            if thumbnail_path:
-                self.parent.shotgun.upload_thumbnail(
-                    entity_type=version_type,
-                    entity_id=version_id,
-                    path=thumbnail_path,
-                )
-                self.logger.info(
-                    f"Uploaded Version thumbnail from path {thumbnail_path}"
-                )
-
             # Remove the temporary directory or files created to generate media content
             self._cleanup_temp_files(media_package_path)
 

--- a/hooks/tk-multi-publish2/basic/upload_version.py
+++ b/hooks/tk-multi-publish2/basic/upload_version.py
@@ -220,7 +220,7 @@ class UploadVersionPlugin(HookBaseClass):
             # be sure to strip the extension from the publish name
             path_components = publisher.util.get_file_path_components(path)
             filename = path_components["filename"]
-            (publish_name, extension) = os.path.splitext(filename)
+            (publish_name, _) = os.path.splitext(filename)
             item.properties["publish_name"] = publish_name
 
             # create the Version in ShotGrid

--- a/hooks/tk-multi-publish2/basic/upload_version.py
+++ b/hooks/tk-multi-publish2/basic/upload_version.py
@@ -556,8 +556,8 @@ class UploadVersionPlugin(HookBaseClass):
         Remove any temporary directories or files from the given path.
 
         If `remove_from_root` is True, the top most level directory of the given path is
-        used to remove all sub directories and files.        
-        
+        used to remove all sub directories and files.
+
         :param path: The file path to remove temporary files and/or directories from.
         :type path: str
         :param remove_from_root: True will remove directories and files from the top most level
@@ -577,10 +577,7 @@ class UploadVersionPlugin(HookBaseClass):
             # Get the top most level of the path that is inside the root temp dir
             relative_path = os.path.relpath(path, tempdir)
             path = os.path.normpath(
-                os.path.join(
-                    tempdir,
-                    relative_path.split(os.path.sep)[0]
-                )
+                os.path.join(tempdir, relative_path.split(os.path.sep)[0])
             )
 
         if os.path.isdir(path):
@@ -588,7 +585,9 @@ class UploadVersionPlugin(HookBaseClass):
         elif os.path.isfile(path):
             os.remove(path)
 
-    def _translate_file_to_lmv(self, item, use_framework_translator, thumbnail_path=None):
+    def _translate_file_to_lmv(
+        self, item, use_framework_translator, thumbnail_path=None
+    ):
         """
         Translate the current Alias file as an LMV package in order to upload it to ShotGrid as a 3D Version
 

--- a/hooks/tk-multi-publish2/basic/upload_version.py
+++ b/hooks/tk-multi-publish2/basic/upload_version.py
@@ -187,9 +187,6 @@ class UploadVersionPlugin(HookBaseClass):
             )
             return False
 
-        # Store the translator in the item properties so it can be used later
-        item.properties["lmv_translator"] = lmv_translator
-
         return True
 
     def publish(self, settings, item):
@@ -585,8 +582,12 @@ class UploadVersionPlugin(HookBaseClass):
             - The path to the temporary folder where the LMV files have been processed
         """
 
+        path = item.get_property("path")
+
         # Translate the file to LMV
-        lmv_translator = item.properties["lmv_translator"]
+        framework_lmv = self.load_framework("tk-framework-lmv_v0.x.x")
+        translator = framework_lmv.import_module("translator")
+        lmv_translator = translator.LMVTranslator(path, self.parent.sgtk, item.context)
         lmv_translator.translate()
 
         # Package up the LMV files into a zip file

--- a/hooks/tk-multi-publish2/basic/upload_version.py
+++ b/hooks/tk-multi-publish2/basic/upload_version.py
@@ -16,7 +16,6 @@ import sgtk
 HookBaseClass = sgtk.get_hook_baseclass()
 
 
-
 class UploadVersionPlugin(HookBaseClass):
     """Plugin for uploading Versions to ShotGrid for review."""
 
@@ -178,7 +177,7 @@ class UploadVersionPlugin(HookBaseClass):
         if not framework_lmv:
             self.logger.error("Could not run LMV translation: missing ATF framework")
             return False
-        
+
         translator = framework_lmv.import_module("translator")
         lmv_translator = translator.LMVTranslator(path, self.parent.sgtk, item.context)
         lmv_translator_path = lmv_translator.get_translator_path()
@@ -262,7 +261,9 @@ class UploadVersionPlugin(HookBaseClass):
                     entity_id=version_id,
                     path=thumbnail_path,
                 )
-                self.logger.info(f"Uploaded Version thumbnail from path {thumbnail_path}")
+                self.logger.info(
+                    f"Uploaded Version thumbnail from path {thumbnail_path}"
+                )
 
             # Remove the temporary directory or files created to generate media content
             self._cleanup_temp_files(media_package_path)
@@ -590,7 +591,9 @@ class UploadVersionPlugin(HookBaseClass):
 
         # Package up the LMV files into a zip file
         file_name = str(item.properties["sg_version_data"]["id"])
-        package_path, lmv_thumbnail_path = lmv_translator.package(svf_file_name=file_name)
+        package_path, lmv_thumbnail_path = lmv_translator.package(
+            svf_file_name=file_name
+        )
 
         return package_path, lmv_thumbnail_path, lmv_translator.output_directory
 

--- a/startup.py
+++ b/startup.py
@@ -80,12 +80,6 @@ class AliasLauncher(SoftwareLauncher):
 
         self.logger.debug("Preparing Alias Launch...")
 
-        # import sys
-        # sys.path.append("C:\\python_libs")
-        # import ptvsd
-        # ptvsd.enable_attach()
-        # ptvsd.wait_for_attach()
-
         try:
             # The alias framework is required to launch Alias with the correct plugin
             framework_location = self.__get_framework_location("tk-framework-alias")


### PR DESCRIPTION
* Use new Alias Python API function to generate an image of the current Alias viewport
* Set the publish default thumbnail to the current Alias viewport and show it in the publish screenshot widget UI
* Allow user to override default thumbnail by using screen grab widget
* Do not use thumbnails generated by LMV