### PR TITLE
Update minimum supported version to 2022.

### DIFF
--- a/startup.py
+++ b/startup.py
@@ -63,7 +63,7 @@ class AliasLauncher(SoftwareLauncher):
     @property
     def minimum_supported_version(self):
         """The minimum software version that is supported by the launcher."""
-        return "2019"
+        return "2022"
 
     def prepare_launch(self, exec_path, args, file_to_open=None):
         """


### PR DESCRIPTION
@rob-aitchison this will modify Alias software found by the launcher, which will not show Alias < 2022.0

Did we want this, or do we prefer a less aggressive method to indicating minimum version support?