### PR TITLE
SG-33518:  Fix Alias startup failure on reading AboutBox.txt file

### DIFF
--- a/startup.py
+++ b/startup.py
@@ -260,8 +260,16 @@ class AliasLauncher(SoftwareLauncher):
             os.path.dirname(alias_bindir), "resources", "AboutBox.txt"
         )
 
-        with open(about_box_file, "r") as f:
-            about_box_file_first_line = f.readline().split("\r")[0].strip()
+        try:
+            # First try to read the file with utf-8 encoding. Any errors will be replaced with
+            # the Unicode replacement.
+            with open(about_box_file, "r", encoding="utf-8", errors="replace") as f:
+                about_box_file_first_line = f.readline().split("\r")[0].strip()
+        except UnicodeDecodeError:
+            # Fallback to trying to read the file with the latin-1 encoding. This encoding is
+            # more lenient.
+            with open(about_box_file, "r", encoding="latin-1") as f:
+                about_box_file_first_line = f.readline().split("\r")[0].strip()
 
         release_prefix = "Alias " + code_name
         releases = about_box_file_first_line.strip().split(",")


### PR DESCRIPTION
* Without specifying encoding on file open, Python will use the system default encoding (typically utf-8) and if any invalid characters are found, it will not raise UnicodeError, but instead will repalce any invalid characters with a Unicode replacement
* Some users may experience errors on file open if their system default encoding is not utf-8. To make sure this works for all users, explicitly define the encoding and replace errors with Unicode replacements.
* Additionally, add extra fallback step to try a more lenient encoding "latin-1"