### PR TITLE
Add tk-framework-lmv requirement

### DIFF
--- a/hooks/tk-multi-publish2/basic/upload_version.py
+++ b/hooks/tk-multi-publish2/basic/upload_version.py
@@ -175,7 +175,9 @@ class UploadVersionPlugin(HookBaseClass):
 
         framework_lmv = self.load_framework("tk-framework-lmv_v1.x.x")
         if not framework_lmv:
-            self.logger.error("Failed to load required framework tk-framework-lmv verison 1.x.x")
+            self.logger.error(
+                "Failed to load required framework tk-framework-lmv verison 1.x.x"
+            )
             return False
 
         translator = framework_lmv.import_module("translator")

--- a/hooks/tk-multi-publish2/basic/upload_version.py
+++ b/hooks/tk-multi-publish2/basic/upload_version.py
@@ -173,7 +173,7 @@ class UploadVersionPlugin(HookBaseClass):
                     "Please contact Autodesk support to have 3D Review enabled on your ShotGrid site or use the 2D Version publish option instead."
                 )
 
-        framework_lmv = self.load_framework("tk-framework-lmv_v0.x.x")
+        framework_lmv = self.load_framework("tk-framework-lmv_v1.x.x")
         if not framework_lmv:
             self.logger.error("Could not run LMV translation: missing ATF framework")
             return False
@@ -585,7 +585,7 @@ class UploadVersionPlugin(HookBaseClass):
         path = item.get_property("path")
 
         # Translate the file to LMV
-        framework_lmv = self.load_framework("tk-framework-lmv_v0.x.x")
+        framework_lmv = self.load_framework("tk-framework-lmv_v1.x.x")
         translator = framework_lmv.import_module("translator")
         lmv_translator = translator.LMVTranslator(path, self.parent.sgtk, item.context)
         lmv_translator.translate()

--- a/hooks/tk-multi-publish2/basic/upload_version.py
+++ b/hooks/tk-multi-publish2/basic/upload_version.py
@@ -175,7 +175,7 @@ class UploadVersionPlugin(HookBaseClass):
 
         framework_lmv = self.load_framework("tk-framework-lmv_v1.x.x")
         if not framework_lmv:
-            self.logger.error("Could not run LMV translation: missing ATF framework")
+            self.logger.error("Failed to load required framework tk-framework-lmv verison 1.x.x")
             return False
 
         translator = framework_lmv.import_module("translator")

--- a/hooks/tk-multi-publish2/basic/upload_version.py
+++ b/hooks/tk-multi-publish2/basic/upload_version.py
@@ -173,16 +173,15 @@ class UploadVersionPlugin(HookBaseClass):
                     "Please contact Autodesk support to have 3D Review enabled on your ShotGrid site or use the 2D Version publish option instead."
                 )
 
-            # framework_lmv = self.load_framework("tk-framework-lmv_v1.x.x")
-            framework_lmv = self.load_framework("tk-framework-lmv_v0.x.x")
+            framework_lmv = self.load_framework("tk-framework-lmv_v1.x.x")
             if not framework_lmv:
-                self.logger.error(
-                    "Missing required framework tk-framework-lmv v1.x.x"
-                )
+                self.logger.error("Missing required framework tk-framework-lmv v1.x.x")
                 return False
 
             translator = framework_lmv.import_module("translator")
-            lmv_translator = translator.LMVTranslator(path, self.parent.sgtk, item.context)
+            lmv_translator = translator.LMVTranslator(
+                path, self.parent.sgtk, item.context
+            )
             lmv_translator_path = lmv_translator.get_translator_path()
             if not lmv_translator_path:
                 self.logger.error(

--- a/hooks/tk-multi-publish2/basic/upload_version.py
+++ b/hooks/tk-multi-publish2/basic/upload_version.py
@@ -173,21 +173,22 @@ class UploadVersionPlugin(HookBaseClass):
                     "Please contact Autodesk support to have 3D Review enabled on your ShotGrid site or use the 2D Version publish option instead."
                 )
 
-        framework_lmv = self.load_framework("tk-framework-lmv_v1.x.x")
-        if not framework_lmv:
-            self.logger.error(
-                "Failed to load required framework tk-framework-lmv verison 1.x.x"
-            )
-            return False
+            # framework_lmv = self.load_framework("tk-framework-lmv_v1.x.x")
+            framework_lmv = self.load_framework("tk-framework-lmv_v0.x.x")
+            if not framework_lmv:
+                self.logger.error(
+                    "Missing required framework tk-framework-lmv v1.x.x"
+                )
+                return False
 
-        translator = framework_lmv.import_module("translator")
-        lmv_translator = translator.LMVTranslator(path, self.parent.sgtk, item.context)
-        lmv_translator_path = lmv_translator.get_translator_path()
-        if not lmv_translator_path:
-            self.logger.error(
-                "Missing translator for Alias. Alias must be installed locally to run LMV translation."
-            )
-            return False
+            translator = framework_lmv.import_module("translator")
+            lmv_translator = translator.LMVTranslator(path, self.parent.sgtk, item.context)
+            lmv_translator_path = lmv_translator.get_translator_path()
+            if not lmv_translator_path:
+                self.logger.error(
+                    "Missing translator for Alias. Alias must be installed locally to run LMV translation."
+                )
+                return False
 
         return True
 

--- a/info.yml
+++ b/info.yml
@@ -80,3 +80,4 @@ requires_core_version: "v0.19.18"
 frameworks:
   - {"name": "tk-framework-aliastranslations", "version": "v0.2.3"}
   - {"name": "tk-framework-alias", "version": "v1.x.x", "minimum_version": "v1.0.1"}
+  - {"name": "tk-framework-lmv", "version": "v1.x.x"}


### PR DESCRIPTION
* Requires v1.x.x due to framework breaking change
* Only validate the framework exists when performing 3D publish (2D does not use the framework and so not required)