### PR TITLE
Update tk-framework-alias min version

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -84,5 +84,5 @@ requires_core_version: "v0.19.18"
 
 frameworks:
   - {"name": "tk-framework-aliastranslations", "version": "v0.2.3"}
-  - {"name": "tk-framework-alias", "version": "v1.x.x", "minimum_version": "v1.0.1"}
+  - {"name": "tk-framework-alias", "version": "v1.x.x", "minimum_version": "v1.2.0"}
   - {"name": "tk-framework-lmv", "version": "v1.x.x"}


### PR DESCRIPTION
tk-framework-alias v1.2.0 required for:
* Alias 2025.0 PySide6 support
* Fix Alias 2024.1 plugin restart bug