### PR TITLE
Release v3.0.4

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -259,8 +259,12 @@ class AliasEngine(sgtk.platform.Engine):
             self.__event_watcher = None
 
         if self.__menu_generator:
-            if not self.__sio or self.__sio.connected:
-                self.__menu_generator.clean_menu()
+            if self.__sio and not self.__sio.connected:
+                self.logger.error(
+                    "No connection to Alias server. Can't remove ShotGrid menu."
+                )
+            else:
+                self.__menu_generator.remove_menu()
             self.__menu_generator = None
 
         # Close all Shotgun app dialogs that are still opened since some apps do threads

--- a/python/tk_alias/menu_generation.py
+++ b/python/tk_alias/menu_generation.py
@@ -142,14 +142,17 @@ class AliasMenuGenerator(object):
 
         if not self.alias_menu:
             return self.engine.alias_py.AlStatusCode.InvalidObject
-        status = self.alias_menu.remove()
+        if hasattr(self.alias_menu, "remove"):
+            status = self.alias_menu.remove()
+        else:
+            status = self.clean_menu()
         self.__alias_menu = None
         return status
 
     def clean_menu(self):
         """Clean the ShotGrid menu in Alias by removing all its entries."""
 
-        self.alias_menu.clean()
+        return self.alias_menu.clean()
 
     def _add_context_menu(self):
         """


### PR DESCRIPTION
* Remove menu on destroy. Menu can be recreated on restart.
* Alias < 2024.0 does not hae 'menu.remove()' method. Use clean up instead.