### PR TITLE
SHOT-4379: Drop support for Alias 2022

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -84,5 +84,5 @@ requires_core_version: "v0.19.18"
 
 frameworks:
   - {"name": "tk-framework-aliastranslations", "version": "v0.x.x", "minimum_version": "v0.2.3"}
-  - {"name": "tk-framework-alias", "version": "v1.x.x", "minimum_version": "v1.4.1"}
+  - {"name": "tk-framework-alias", "version": "v1.x.x", "minimum_version": "v2.0.0"}
   - {"name": "tk-framework-lmv", "version": "v1.x.x"}


### PR DESCRIPTION
* Update tk-framework-alias minimum version which removes files for Alias 2022 support

_**DO NOT MERGE until tk-framework-alias v2.0.0 is released**_