### PR TITLE
SG-35865- Add High-DPI support to the Alias integration

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -442,9 +442,22 @@ class AliasEngine(sgtk.platform.Engine):
         if os.path.exists(plugins_dir):
             QtCore.QCoreApplication.addLibraryPath(plugins_dir)
 
-        # Enable High DPI support in Qt5 (default enabled in Qt6)
         if QtCore.qVersion()[0] == "5":
-            QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
+            # Enable High DPI support in Qt5 (default enabled in Qt6)
+            #
+            # Only enable it if none of the Qt environment variables related to
+            # High-DPI are set
+
+            if "QT_AUTO_SCREEN_SCALE_FACTOR" in os.environ:
+                pass
+            elif "QT_SCALE_FACTOR" in os.environ:
+                pass
+            elif "QT_SCREEN_SCALE_FACTORS" in os.environ:
+                pass
+            else:
+                QtCore.QCoreApplication.setAttribute(
+                    QtCore.Qt.AA_EnableHighDpiScaling
+                )
 
         self.__qt_app = QtGui.QApplication.instance()
         if not self.__qt_app:

--- a/engine.py
+++ b/engine.py
@@ -442,6 +442,10 @@ class AliasEngine(sgtk.platform.Engine):
         if os.path.exists(plugins_dir):
             QtCore.QCoreApplication.addLibraryPath(plugins_dir)
 
+        # Enable High DPI support in Qt5 (default enabled in Qt6)
+        if QtCore.qVersion()[0] == "5":
+            QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
+
         self.__qt_app = QtGui.QApplication.instance()
         if not self.__qt_app:
             self.__qt_app = QtGui.QApplication(

--- a/engine.py
+++ b/engine.py
@@ -455,9 +455,7 @@ class AliasEngine(sgtk.platform.Engine):
             elif "QT_SCREEN_SCALE_FACTORS" in os.environ:
                 pass
             else:
-                QtCore.QCoreApplication.setAttribute(
-                    QtCore.Qt.AA_EnableHighDpiScaling
-                )
+                QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
 
         self.__qt_app = QtGui.QApplication.instance()
         if not self.__qt_app:


### PR DESCRIPTION
Enable the `AA_EnableHighDpiScaling` property before instantiating the QApplication.

Related to shotgunsoftware/tk-framework-alias#58