### PR TITLE
SHOT-4392: Fixes for Alias with Qt6

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -375,7 +375,6 @@ class AliasEngine(sgtk.platform.Engine):
         # Apply Alias specific styling
         app = QtGui.QApplication.instance()
         app_palette = app.palette()
-
         # The default placeholder text for Alias is black, let's set it back to
         # the text color (as it was in Qt5), but with the current placeholder
         # text alpha value.
@@ -383,7 +382,7 @@ class AliasEngine(sgtk.platform.Engine):
         placeholder_text_color = app_palette.placeholderText().color()
         new_placeholder_text_color.setAlpha(placeholder_text_color.alpha())
         app_palette.setColor(QtGui.QPalette.PlaceholderText, new_placeholder_text_color)
-
+        # Set the palette back with the Alias specific styling
         app.setPalette(app_palette)
 
     # -------------------------------------------------------------------------------------------------------

--- a/engine.py
+++ b/engine.py
@@ -360,6 +360,32 @@ class AliasEngine(sgtk.platform.Engine):
         # TODO: improve Alias API to redirect the logs to the Alias Promptline
         pass
 
+    def _initialize_dark_look_and_feel(self):
+        """
+        Override the base engine method.
+
+        Apply specific styling for Alias.
+        """
+
+        from sgtk.platform.qt import QtGui
+
+        # Initialize the SG Toolkit style to the application.
+        super()._initialize_dark_look_and_feel()
+
+        # Apply Alias specific styling
+        app = QtGui.QApplication.instance()
+        app_palette = app.palette()
+
+        # The default placeholder text for Alias is black, let's set it back to
+        # the text color (as it was in Qt5), but with the current placeholder
+        # text alpha value.
+        new_placeholder_text_color = app_palette.text().color()
+        placeholder_text_color = app_palette.placeholderText().color()
+        new_placeholder_text_color.setAlpha(placeholder_text_color.alpha())
+        app_palette.setColor(QtGui.QPalette.PlaceholderText, new_placeholder_text_color)
+
+        app.setPalette(app_palette)
+
     # -------------------------------------------------------------------------------------------------------
     # Public methods
     # -------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
* Need to initialize the placeholder text color (default is black, and not very visible)