### PR TITLE
SHOT-4396: Shut down Alias Engine properly

### DIFF
--- a/python/tk_alias/shotgrid_alias_client.py
+++ b/python/tk_alias/shotgrid_alias_client.py
@@ -49,6 +49,8 @@ class ShotGridAliasSocketIoClient(AliasSocketIoClient):
         """Clean up the client on disconnect."""
 
         super(ShotGridAliasSocketIoClient, self).cleanup()
+        if self.__qt_app:
+            self.engine.execute_in_main_thread(self.__qt_app.quit)
         self.__qt_app = None
 
     def _process_events(self):


### PR DESCRIPTION
* Currently the Alias engine is not shut down properly when Alias is force closed causing FPTR to fail to start up the next time launched
* Ensure the FPTR qt app is exited and Alias Engine is shut down when Alias is force closed
* Qt app quit will trigger the engine shutdown