### PR TITLE
SG-36346 Dynamic hard drive lookup in windows

### DIFF
--- a/startup.py
+++ b/startup.py
@@ -49,7 +49,9 @@ class AliasLauncher(SoftwareLauncher):
 
     # Example: C:\Program Files\Autodesk\AliasAutoStudio2019\bin\Alias.exe
     # <drive> will be replaced later with the available drive letters
-    BASE_TEMPLATE = r"<drive>:\Program Files\Autodesk\Alias{code_name}{version}\bin\Alias.exe"
+    BASE_TEMPLATE = (
+        r"<drive>:\Program Files\Autodesk\Alias{code_name}{version}\bin\Alias.exe"
+    )
 
     @property
     def minimum_supported_version(self):
@@ -201,7 +203,7 @@ class AliasLauncher(SoftwareLauncher):
                 for d in self._get_used_drive_letters()
             ],
         }
-        
+
         # all the executable templates for the current OS
         executable_templates = self.EXECUTABLE_TEMPLATES.get(sys.platform, [])
 
@@ -296,7 +298,7 @@ class AliasLauncher(SoftwareLauncher):
         except:
             # Fallback
             return ["C"]
-    
+
     ##########################################################################################
     # private methods
 

--- a/startup.py
+++ b/startup.py
@@ -197,7 +197,7 @@ class AliasLauncher(SoftwareLauncher):
         # of the supported operating systems. The templates are used for both
         # globbing and regex matches by replacing the named format placeholders
         # with an appropriate glob or regex string.
-        self.EXECUTABLE_TEMPLATES = {
+        templates = {
             "win32": [
                 self.BASE_TEMPLATE.replace("<drive>", d)
                 for d in self._get_used_drive_letters()
@@ -205,7 +205,7 @@ class AliasLauncher(SoftwareLauncher):
         }
 
         # all the executable templates for the current OS
-        executable_templates = self.EXECUTABLE_TEMPLATES.get(sys.platform, [])
+        executable_templates = templates.get(sys.platform, [])
 
         # all the discovered executables
         sw_versions = []
@@ -218,7 +218,7 @@ class AliasLauncher(SoftwareLauncher):
             )
 
             # Extract all products from that executable.
-            for (executable_path, key_dict) in executable_matches:
+            for executable_path, key_dict in executable_matches:
                 # extract the matched keys form the key_dict (default to None if
                 # not included)
                 version = key_dict.get("version")
@@ -287,8 +287,7 @@ class AliasLauncher(SoftwareLauncher):
 
         return release_version
 
-    @staticmethod
-    def _get_used_drive_letters():
+    def _get_used_drive_letters(self):
         try:
             import win32api
 
@@ -297,6 +296,9 @@ class AliasLauncher(SoftwareLauncher):
             return [d[0] for d in drives]
         except:
             # Fallback
+            self.logger.debug(
+                f"win32api not available. Falling back to default drive letter C:"
+            )
             return ["C"]
 
     ##########################################################################################


### PR DESCRIPTION
## Description
Introducing `win32api.GetLogicalDriveStrings()` to get the list of available drive letters in Windows.

In terms of performance, `win32api.GetLogicalDriveStrings()` is generally very fast and efficient. It directly interfaces with the Windows API to get the list of logical drives, which is a relatively quick operation. 

Regarding the `glob` search, I've done lookup tests with a few different drive letters and it works with no major difference in performance.

## Testing

Install Alias software in a different drive than C:. SGD should be able to locate the software and add its icon normally.