### PR TITLE
SG-32814 Review and unify code handling supported DCC versions

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -1084,6 +1084,9 @@ class AliasEngine(sgtk.platform.Engine):
             self.logger.debug("Couldn't get Alias version. Skip version comparison")
             return False
 
+
+        ## TODO
+
         if int(self.alias_version[0:4]) > self.get_setting(
             "compatibility_dialog_min_version", 2020
         ):
@@ -1093,7 +1096,7 @@ class AliasEngine(sgtk.platform.Engine):
                 "experience bugs or instability.  Please report any issues you see "
                 "to %s" % (self.alias_version, sgtk.support_url)
             )
-            self.logger.warning(msg)
+            self.logger.warning(msg)l
             if self.has_ui:
                 QtGui.QMessageBox.warning(
                     self._get_dialog_parent(),

--- a/engine.py
+++ b/engine.py
@@ -1087,6 +1087,8 @@ class AliasEngine(sgtk.platform.Engine):
 
         from sgtk.platform.qt import QtGui
 
+        url_doc_supported_versions = "https://help.autodesk.com/view/SGDEV/ENU/?guid=SGD_si_integrations_engine_supported_versions_html"
+
         if not self.alias_version:
             self.logger.debug("Couldn't get Alias version. Skip version comparison")
 
@@ -1105,7 +1107,7 @@ For information regarding support engine versions, please visit this page:
                             70
                         ),
                         message=message.replace(
-                            # Precense of \n breaks the Rich Text Format
+                            # Presence of \n breaks the Rich Text Format
                             "\n",
                             "<br>",
                         ).format(
@@ -1132,7 +1134,6 @@ For information regarding support engine versions, please visit this page:
                 )
             )
 
-        url_doc_supported_versions = "https://help.autodesk.com/view/SGDEV/ENU/?guid=SGD_si_integrations_engine_supported_versions_html"
         alias_major_year = int(self.alias_version[0:4])
 
         if alias_major_year < VERSION_OLDEST_COMPATIBLE:
@@ -1153,7 +1154,7 @@ For information regarding support engine versions, please visit this page:
                             70
                         ),
                         message.replace(
-                            # Precense of \n breaks the Rich Text Format
+                            # Presence of \n breaks the Rich Text Format
                             "\n",
                             "<br>",
                         ).format(
@@ -1207,7 +1208,7 @@ For information regarding support engine versions, please visit this page:
 {url_doc_supported_versions}
                     """.strip()
                     .replace(
-                        # Precense of \n breaks the Rich Text Format
+                        # Presence of \n breaks the Rich Text Format
                         "\n",
                         "<br>",
                     )
@@ -1224,12 +1225,11 @@ For information regarding support engine versions, please visit this page:
                     ),
                 )
 
-        elif alias_major_year < VERSION_NEWEST_SUPPORTED:
+        elif alias_major_year <= VERSION_NEWEST_SUPPORTED:
             # Within the range of supported versions
             self.logger.debug(f"Running Alias version {self.alias_version}")
 
-        else:
-            # Newer than the newest supported version: untested
+        else:  # Newer than the newest supported version (untested)
             self.logger.warning(
                 "Flow Production Tracking has not yet been fully tested with "
                 "{product} version {version}.".format(
@@ -1255,7 +1255,7 @@ Please report any issues to:
 {support_url}
                     """.strip()
                     .replace(
-                        # Precense of \n breaks the Rich Text Format
+                        # Presence of \n breaks the Rich Text Format
                         "\n",
                         "<br>",
                     )

--- a/engine.py
+++ b/engine.py
@@ -18,7 +18,7 @@ import sgtk
 from sgtk.util import LocalFileStorageManager
 
 # VRED versions compatibility constants
-VERSION_OLDEST_COMPATIBLE = 2020
+VERSION_OLDEST_COMPATIBLE = 2023
 VERSION_OLDEST_SUPPORTED = 2023
 VERSION_NEWEST_SUPPORTED = 2026
 # Caution: make sure compatibility_dialog_min_version default value in info.yml
@@ -1110,12 +1110,12 @@ For information regarding support engine versions, please visit this page:
                             "<br>",
                         ).format(
                             product="Alias",
-                            url_doc_supported_versions='<a href="{u}">{u}</a>'.format(
+                            url_doc_supported_versions='<a style="color: #5fd2df" href="{u}">{u}</a>'.format(
                                 u=url_doc_supported_versions,
                             ),
                         ),
                     )
-                except:  # Ignore B110
+                except:  # nosec B110
                     # It is unlikely that the above message will go through
                     # on old versions of Alias (Python2, Qt4, ...).
                     # But there is nothing more we can do here.
@@ -1154,13 +1154,13 @@ For information regarding support engine versions, please visit this page:
                             "<br>",
                         ).format(
                             product="Alias",
-                            url_doc_supported_versions='<a href="{u}">{u}</a>'.format(
+                            url_doc_supported_versions='<a style="color: #5fd2df" href="{u}">{u}</a>'.format(
                                 u=url_doc_supported_versions,
                             ),
                             version=VERSION_OLDEST_COMPATIBLE,
                         ),
                     )
-                except:  # Ignore B110
+                except:  # nosec B110
                     # It is unlikely that the above message will go through
                     # on old versions of VRED (Python2, Qt4, ...).
                     # But there is nothing more we can do here.
@@ -1205,7 +1205,7 @@ For information regarding support engine versions, please visit this page:
                     )
                     .format(
                         product="Alias",
-                        url_doc_supported_versions='<a href="{u}">{u}</a>'.format(
+                        url_doc_supported_versions='<a style="color: #5fd2df" href="{u}">{u}</a>'.format(
                             u=url_doc_supported_versions,
                         ),
                         version=VERSION_OLDEST_SUPPORTED,
@@ -1249,7 +1249,7 @@ Please report any issues to:
                     )
                     .format(
                         product="Alias",
-                        support_url='<a href="{u}">{u}</a>'.format(
+                        support_url='<a style="color: #5fd2df" href="{u}">{u}</a>'.format(
                             u=sgtk.support_url,
                         ),
                         version=self.alias_version,

--- a/engine.py
+++ b/engine.py
@@ -1222,7 +1222,7 @@ For information regarding support engine versions, please visit this page:
                 "Flow Production Tracking has not yet been fully tested with "
                 "{product} version {version}.".format(
                     product="Alias",
-                    version=self.max_version_year,
+                    version=self.alias_version,
                 )
             )
 

--- a/engine.py
+++ b/engine.py
@@ -1110,8 +1110,12 @@ For information regarding support engine versions, please visit this page:
                             "<br>",
                         ).format(
                             product="Alias",
-                            url_doc_supported_versions='<a style="color: #5fd2df" href="{u}">{u}</a>'.format(
+                            url_doc_supported_versions='<a style="color: {color}" href="{u}">{u}</a>'.format(
                                 u=url_doc_supported_versions,
+                                color=sgtk.platform.constants.SG_STYLESHEET_CONSTANTS.get(
+                                    "SG_HIGHLIGHT_COLOR",
+                                    "#18A7E3",
+                                ),
                             ),
                         ),
                     )
@@ -1156,6 +1160,10 @@ For information regarding support engine versions, please visit this page:
                             product="Alias",
                             url_doc_supported_versions='<a style="color: #5fd2df" href="{u}">{u}</a>'.format(
                                 u=url_doc_supported_versions,
+                                color=sgtk.platform.constants.SG_STYLESHEET_CONSTANTS.get(
+                                    "SG_HIGHLIGHT_COLOR",
+                                    "#18A7E3",
+                                ),
                             ),
                             version=VERSION_OLDEST_COMPATIBLE,
                         ),
@@ -1205,8 +1213,12 @@ For information regarding support engine versions, please visit this page:
                     )
                     .format(
                         product="Alias",
-                        url_doc_supported_versions='<a style="color: #5fd2df" href="{u}">{u}</a>'.format(
+                        url_doc_supported_versions='<a style="color: {color}" href="{u}">{u}</a>'.format(
                             u=url_doc_supported_versions,
+                            color=sgtk.platform.constants.SG_STYLESHEET_CONSTANTS.get(
+                                "SG_HIGHLIGHT_COLOR",
+                                "#18A7E3",
+                            ),
                         ),
                         version=VERSION_OLDEST_SUPPORTED,
                     ),
@@ -1249,8 +1261,12 @@ Please report any issues to:
                     )
                     .format(
                         product="Alias",
-                        support_url='<a style="color: #5fd2df" href="{u}">{u}</a>'.format(
+                        support_url='<a style="color: {color}" href="{u}">{u}</a>'.format(
                             u=sgtk.support_url,
+                            color=sgtk.platform.constants.SG_STYLESHEET_CONSTANTS.get(
+                                "SG_HIGHLIGHT_COLOR",
+                                "#18A7E3",
+                            ),
                         ),
                         version=self.alias_version,
                     ),

--- a/startup.py
+++ b/startup.py
@@ -56,7 +56,7 @@ class AliasLauncher(SoftwareLauncher):
     @property
     def minimum_supported_version(self):
         """The minimum software version that is supported by the launcher."""
-        return "2022"
+        return "2023"
 
     def prepare_launch(self, exec_path, args, file_to_open=None):
         """


### PR DESCRIPTION
Differentiate warning messages between the oldest compatible version and the oldest supported version.


# Changes aligned with other TK engines

- shotgunsoftware/tk-3dsmax#49
- shotgunsoftware/tk-houdini#81
- shotgunsoftware/tk-mari#30
- shotgunsoftware/tk-maya#122
- shotgunsoftware/tk-motionbuilder#36
- shotgunsoftware/tk-nuke#116
- shotgunsoftware/tk-vred#134


# Screenshots

Note: Please ignore the exact versions in the screenshots below. I had to tweak the code to issue those. 

* Error message when VRED version is older than the oldest **compatible** version
  ![2025-05-08_16-32](https://github.com/user-attachments/assets/8defc1eb-c29c-40f6-99b4-5fb886471164)

* Warning message when VRED version is older than the oldest **supported** version
  ![2025-05-08_16-34](https://github.com/user-attachments/assets/c67e7c09-dd61-4e04-bf35-49870ec6eb2a)

* Warning message when VRED version is newer than the newest **supported** version
  ![2025-05-08_16-30](https://github.com/user-attachments/assets/f4df0f07-1bbb-4e62-825b-ea3c42f7c783)
