### PR TITLE
SHOT-4430: Block publish Export Selection if nothing selected

### DIFF
--- a/hooks/tk-multi-publish2/basic/publish_session.py
+++ b/hooks/tk-multi-publish2/basic/publish_session.py
@@ -230,7 +230,8 @@ class AliasSessionPublishPlugin(HookBaseClass):
             # init the first pick item, and check that there is at least one
             # item selected.
             alias_api.first_pick_item()
-            if not alias_api.get_current_pick_item():
+            current_pick_item = alias_api.get_current_pick_item()
+            if not current_pick_item:
                 error_msg = "Nothing selected, please select the items you would like to include in the publish or switch the Publish Mode to 'Default'"
                 self.logger.error(error_msg)
                 return False

--- a/hooks/tk-multi-publish2/basic/publish_session.py
+++ b/hooks/tk-multi-publish2/basic/publish_session.py
@@ -227,7 +227,7 @@ class AliasSessionPublishPlugin(HookBaseClass):
                 self.logger.error(error_msg)
                 return False
             # Ensure the user has selected something to export. Use Alias API to
-            # init the first pick item, and check that there is at least one
+            # initialize the first pick item, and check that there is at least one
             # item selected.
             alias_api.first_pick_item()
             current_pick_item = alias_api.get_current_pick_item()

--- a/hooks/tk-multi-publish2/basic/publish_session.py
+++ b/hooks/tk-multi-publish2/basic/publish_session.py
@@ -226,6 +226,14 @@ class AliasSessionPublishPlugin(HookBaseClass):
                 error_msg = "Export Selection mode is not supported with Background Publishing. Please change the Publish Mode or turn off Background Publishing."
                 self.logger.error(error_msg)
                 return False
+            # Ensure the user has selected something to export. Use Alias API to
+            # init the first pick item, and check that there is at least one
+            # item selected.
+            alias_api.first_pick_item()
+            if not alias_api.get_current_pick_item():
+                error_msg = "Nothing selected, please select the items you would like to include in the publish or switch the Publish Mode to 'Default'"
+                self.logger.error(error_msg)
+                return False
 
         # ---- ensure the session has been saved
 


### PR DESCRIPTION
* Validate will fail and provide error message if publish mode is set to 'Export Selection' but nothing is selected
* User will not be able to publish until at least one object is selected in the Alias scene
* This is to avoid the user publishing selection with nothing selected, which results in Alias not saving a file at all