### PR TITLE
SHOT-4450: Fix loader actions in Alias

### DIFF
--- a/docs/v4.1.8.rst
+++ b/docs/v4.1.8.rst
@@ -6,6 +6,7 @@ Release highlights
 
 * Alias Learning Edition is now supported
 * Require selection when publishing mode `Export Selection` is enabled
+* Bug fix for Loader2 App actions
 
 New Features
 -----------------
@@ -16,3 +17,9 @@ Improvements
 -----------------
 
 On publish, if the `Export Selection` mode is enabled, the publish will require a selection to be made in Alias. The publish will not validate successfully, until at least one object is selected in the Alias scene. This is to prevent trying to publish an empty file, which will result in not creating a new published file on disk.
+
+Bug Fixes
+-----------------
+
+* Fixed issue with executing Loader2 App actions (bug introduced in v4.1.5)
+* Reported issue for "Import as Reference" action has been fixed

--- a/hooks/tk-multi-loader2/basic/scene_actions.py
+++ b/hooks/tk-multi-loader2/basic/scene_actions.py
@@ -152,12 +152,11 @@ class AliasActions(HookBaseClass):
         :param list actions: Action dictionaries.
         """
 
-        with self.alias_py.request_context_manager(is_async=True):
-            for single_action in actions:
-                name = single_action["name"]
-                sg_publish_data = single_action["sg_publish_data"]
-                params = single_action["params"]
-                self.execute_action(name, params, sg_publish_data)
+        for single_action in actions:
+            name = single_action["name"]
+            sg_publish_data = single_action["sg_publish_data"]
+            params = single_action["params"]
+            self.execute_action(name, params, sg_publish_data)
 
     def execute_action(self, name, params, sg_publish_data):
         """


### PR DESCRIPTION
* Context manager was introduced to execute actions in batch to improve performance time of executing actions, but we cannot use the context manager here since it gathers all Alias Python API request within the context and only executes them after the context has exited; however, an action may need to get the result of the Alias Python API request immediately in order to execute the main action function